### PR TITLE
Changes for v13 support

### DIFF
--- a/module/chat/chat.mjs
+++ b/module/chat/chat.mjs
@@ -2,9 +2,15 @@ import { OutgunnedInteractiveChat } from './interactive-chat.mjs';
 import { OutgunnedActorDetails } from '../apps/actorDetails.mjs';
 
 export function addChatListeners(html) {
-  html.on('click', '.cardbutton', OutgunnedInteractiveChat.triggerChatButton)
-  return
+  html.addEventListener('click', event => {
+    // Check if the clicked element or one of its parents has the class "cardbutton"
+    const button = event.target.closest('.cardbutton')
+    if (!button) return
+
+    OutgunnedInteractiveChat.triggerChatButton(event)
+  })
 }
+
 
 
 export class OutgunnedChat{

--- a/module/chat/interactive-chat.mjs
+++ b/module/chat/interactive-chat.mjs
@@ -7,16 +7,20 @@ export class OutgunnedInteractiveChat {
 
 static  async triggerChatButton(event){
     ui.chat.scrollBottom()
-    const targetElement = event.currentTarget;
+    const targetElement = event.target.closest('.cardbutton');
+    if (!targetElement) {
+      console.error("triggerChatButton: No element with class .cardbutton found.");
+      return;
+    }
     const presetType = targetElement.dataset?.preset;
-    const targetChat = $(targetElement).closest('.message');
-    let targetChatId = targetChat[0].dataset.messageId;
+    const targetChat = targetElement.closest('.message');
+    let targetChatId = targetChat?.dataset?.messageId;
 
     let origin = game.user.id;
     let originGM = game.user.isGM;
 
     //Call confirmation
-    let confirmation = await OutgunnedUtilities.confirmation(presetType, "chatMsg")
+    const confirmation = await OutgunnedUtilities.confirmation(presetType, "chatMsg")
     if (!confirmation) {return}
     
     //If this is GM then call the handleChatButton, otherwise it's a player in which case trigger Socket emit for the GM to act on

--- a/module/setup/context-menu.mjs
+++ b/module/setup/context-menu.mjs
@@ -19,7 +19,10 @@ export class OutgunnedContextMenu extends ContextMenu
   _setPosition(html, target)
   {
     super._setPosition(html, target);
-    html.css(foundry.utils.mergeObject(this._position, s_DEFAULT_STYLE));
+	const pos = foundry.utils.mergeObject(this._position ?? {}, s_DEFAULT_STYLE);
+	html.style.position = pos.position;
+	Object.assign(html.style, pos);
+
   }
 }
 

--- a/module/setup/layers.mjs
+++ b/module/setup/layers.mjs
@@ -26,7 +26,7 @@ class OutgunnedLayer extends PlaceablesLayer {
 }
 
   export class OutgunnedMenu {
-    static getButtons (controls) {
+    static getButtons ({ controls }) {
 
       let usePlanB1icon = "game-icon game-icon-bullet"
       let usePlanB2icon = "game-icon game-icon-backup"
@@ -42,8 +42,16 @@ class OutgunnedLayer extends PlaceablesLayer {
         usePlanBWOK4icon = game.settings.get('outgunned','planBWOKIcon-4')
       }
 
+	  if (!controls) {
+		console.warn("OutgunnedMenu.getButtons: controls is undefined", controls);
+		return;
+	  }
 
-      canvas.outgunnedgmtools = new OutgunnedLayer()
+	  // Create the layer only once
+	  if (!canvas.outgunnedgmtools) {
+		canvas.outgunnedgmtools = new OutgunnedLayer();
+	  }
+      
       const isGM = game.user.isGM
       controls.push({
         icon: "fas fa-gun",
@@ -139,8 +147,8 @@ class OutgunnedLayer extends PlaceablesLayer {
   
     static renderControls (app, html, data) {
       const isGM = game.user.isGM
-      const gmMenu = html.find('.fas-fa-tools').parent()
-      gmMenu.addClass('outgunned-menu')
+      const gmMenu = html.querySelector('.fas-fa-tools')?.parentElement;
+      if (gmMenu) gmMenu.classList.add('outgunned-menu');
     }
   }  
 

--- a/system.json
+++ b/system.json
@@ -2,11 +2,11 @@
   "id": "outgunned",
   "title": "Outgunned",
   "description": "The Outgunned system for FoundryVTT!",
-  "version": "12.17",
+  "version": "13.0",
   "compatibility": {
     "minimum": 12,
-    "verified": "12.331",
-    "maximum": 12
+    "verified": "13",
+    "maximum": 13
   },
   "authors": [
     {"name": "Dangermouse"},


### PR DESCRIPTION
Added minimal changes to support Foundry VTT v13.
Tested via creating characters and running basic solo game in v13. Please test additional features I may have missed and compatibility with v12.

Known TODOs:
- Actors, Items, ActorSheet, ItemSheet, PlaceablesLayer, ContextMenu are all moving in the name space and will be removed in v15
- renderChatMessage hook is deprecated, use renderChatMessageHTML instead. Slated for removal in v15.
- likely other v13 deprecation slated for v15 removal